### PR TITLE
Update 2021-12-23-welcome-to-jekyll.markdown

### DIFF
--- a/_posts/2021-12-23-welcome-to-jekyll.markdown
+++ b/_posts/2021-12-23-welcome-to-jekyll.markdown
@@ -7,7 +7,7 @@ categories: jekyll update
 You’ll find this post in your `_posts` directory. Go ahead and edit it and re-build the site to see your changes. You can rebuild the site in many different ways, but the most common way is to run `jekyll serve`, which launches a web server and auto-regenerates your site when a file is updated.
 
 Jekyll requires blog post files to be named according to the following format:
-
+line before any change
 `YEAR-MONTH-DAY-title.MARKUP`
 This is a new blog post
 
@@ -17,7 +17,7 @@ Jekyll also offers powerful support for code snippets:
 
 {% highlight ruby %}
 def print_hi(name)
-  puts "Hi, #{name}"
+  puts "Hi, #{name}, how are you?"
 end
 print_hi('Tom')
 #=> prints 'Hi, Tom' to STDOUT.
@@ -28,4 +28,5 @@ Check out the [Jekyll docs][jekyll-docs] for more info on how to get the most ou
 [jekyll-docs]: https://jekyllrb.com/docs/home
 [jekyll-gh]:   https://github.com/jekyll/jekyll
 [jekyll-talk]: https://talk.jekyllrb.com/
+
 

--- a/_posts/2021-12-23-welcome-to-jekyll.markdown
+++ b/_posts/2021-12-23-welcome-to-jekyll.markdown
@@ -9,6 +9,7 @@ You’ll find this post in your `_posts` directory. Go ahead and edit it and re-
 Jekyll requires blog post files to be named according to the following format:
 
 `YEAR-MONTH-DAY-title.MARKUP`
+This is a new blog post
 
 Where `YEAR` is a four-digit number, `MONTH` and `DAY` are both two-digit numbers, and `MARKUP` is the file extension representing the format used in the file. After that, include the necessary front matter. Take a look at the source for this post to get an idea about how it works.
 
@@ -27,3 +28,4 @@ Check out the [Jekyll docs][jekyll-docs] for more info on how to get the most ou
 [jekyll-docs]: https://jekyllrb.com/docs/home
 [jekyll-gh]:   https://github.com/jekyll/jekyll
 [jekyll-talk]: https://talk.jekyllrb.com/
+


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds unrelated text snippets to a Jekyll welcome post, disrupting the documentation flow and creating inconsistencies.

Changes made:
- Added "line before any change" text that interrupts Jekyll naming convention explanation
- Added "This is a new blog post" between format example and its description (previously flagged issue)
- Modified Ruby code example greeting but left comment describing old output
- Added trailing blank lines

Issues identified:
- Documentation quality degraded with inserted text breaking the logical flow of Jekyll format explanation
- Code comment no longer matches actual output of modified Ruby example

<h3>Confidence Score: 2/5</h3>

- This PR degrades documentation quality with unrelated text insertions and introduces inconsistencies
- Score reflects documentation disruption with unrelated text that breaks the flow of the Jekyll naming convention explanation, plus an inconsistent code comment that no longer matches the actual output
- The blog post file requires attention to remove unrelated text insertions and fix the inconsistent comment

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| _posts/2021-12-23-welcome-to-jekyll.markdown | Documentation disrupted with unrelated text insertions and inconsistent code example output comment |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Author
    participant BlogPost as Jekyll Blog Post
    participant Reader
    
    Author->>BlogPost: Add "line before any change" text (line 10)
    Author->>BlogPost: Add "This is a new blog post" text (line 12)
    Author->>BlogPost: Modify greeting in Ruby example
    Author->>BlogPost: Add blank lines at end
    
    Note over BlogPost: Documentation flow disrupted
    Note over BlogPost: Comment doesn't match code output
    
    BlogPost->>Reader: Display confusing documentation
    Reader->>Reader: Confused by unrelated text in format explanation
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->