### PR TITLE
Update 2021-12-23-welcome-to-jekyll.markdown

### DIFF
--- a/_posts/2021-12-23-welcome-to-jekyll.markdown
+++ b/_posts/2021-12-23-welcome-to-jekyll.markdown
@@ -9,6 +9,7 @@ You’ll find this post in your `_posts` directory. Go ahead and edit it and re-
 Jekyll requires blog post files to be named according to the following format:
 
 `YEAR-MONTH-DAY-title.MARKUP`
+This is my first blog
 
 Where `YEAR` is a four-digit number, `MONTH` and `DAY` are both two-digit numbers, and `MARKUP` is the file extension representing the format used in the file. After that, include the necessary front matter. Take a look at the source for this post to get an idea about how it works.
 
@@ -27,3 +28,4 @@ Check out the [Jekyll docs][jekyll-docs] for more info on how to get the most ou
 [jekyll-docs]: https://jekyllrb.com/docs/home
 [jekyll-gh]:   https://github.com/jekyll/jekyll
 [jekyll-talk]: https://talk.jekyllrb.com/
+


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a personal statement "This is my first blog" to a Jekyll welcome post template and includes a trailing blank line. The personal text is inserted in the middle of technical documentation explaining Jekyll's file naming convention, disrupting the flow of the tutorial content.

- Added personal statement between file format example and its explanation
- Added blank line at end of file
- Both issues have been previously flagged in review comments

<h3>Confidence Score: 3/5</h3>

- Safe to merge but contains content quality issues that disrupt documentation flow
- Changes are functionally safe (no runtime errors or security issues), but the personal statement interrupts technical documentation and reduces content quality. Previous review comments flagged these same issues.
- The markdown file needs attention to remove the interrupting personal statement and trailing whitespace

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| _posts/2021-12-23-welcome-to-jekyll.markdown | Added personal statement that disrupts documentation flow and trailing blank line |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Author
    participant Jekyll Post
    participant Jekyll Engine
    participant Website
    
    Author->>Jekyll Post: Add "This is my first blog" text
    Author->>Jekyll Post: Add trailing blank line
    Jekyll Post->>Jekyll Engine: Process markdown file
    Jekyll Engine->>Jekyll Engine: Parse front matter
    Jekyll Engine->>Jekyll Engine: Render markdown content
    Note over Jekyll Engine: Text appears mid-paragraph<br/>in technical documentation
    Jekyll Engine->>Website: Generate HTML page
    Website->>Website: Display interrupting text<br/>in file naming explanation
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->