### PR TITLE
Hofm t patch 10

### DIFF
--- a/_posts/2021-12-23-welcome-to-jekyll.markdown
+++ b/_posts/2021-12-23-welcome-to-jekyll.markdown
@@ -9,7 +9,7 @@ You’ll find this post in your `_posts` directory. Go ahead and edit it and re-
 Jekyll requires blog post files to be named according to the following format:
 
 `YEAR-MONTH-DAY-title.MARKUP`
-this is my first blog psot
+this is my first blog post
 
 Where `YEAR` is a four-digit number, `MONTH` and `DAY` are both two-digit numbers, and `MARKUP` is the file extension representing the format used in the file. After that, include the necessary front matter. Take a look at the source for this post to get an idea about how it works.
 
@@ -28,4 +28,5 @@ Check out the [Jekyll docs][jekyll-docs] for more info on how to get the most ou
 [jekyll-docs]: https://jekyllrb.com/docs/home
 [jekyll-gh]:   https://github.com/jekyll/jekyll
 [jekyll-talk]: https://talk.jekyllrb.com/
+
 

--- a/_posts/2021-12-23-welcome-to-jekyll.markdown
+++ b/_posts/2021-12-23-welcome-to-jekyll.markdown
@@ -9,6 +9,7 @@ You’ll find this post in your `_posts` directory. Go ahead and edit it and re-
 Jekyll requires blog post files to be named according to the following format:
 
 `YEAR-MONTH-DAY-title.MARKUP`
+this is my first blog psot
 
 Where `YEAR` is a four-digit number, `MONTH` and `DAY` are both two-digit numbers, and `MARKUP` is the file extension representing the format used in the file. After that, include the necessary front matter. Take a look at the source for this post to get an idea about how it works.
 
@@ -27,3 +28,4 @@ Check out the [Jekyll docs][jekyll-docs] for more info on how to get the most ou
 [jekyll-docs]: https://jekyllrb.com/docs/home
 [jekyll-gh]:   https://github.com/jekyll/jekyll
 [jekyll-talk]: https://talk.jekyllrb.com/
+

--- a/_posts/2021-12-23-welcome-to-jekyll.markdown
+++ b/_posts/2021-12-23-welcome-to-jekyll.markdown
@@ -9,7 +9,7 @@ You’ll find this post in your `_posts` directory. Go ahead and edit it and re-
 Jekyll requires blog post files to be named according to the following format:
 
 `YEAR-MONTH-DAY-title.MARKUP`
-this is my first blog post
+this is my first blog post.
 
 Where `YEAR` is a four-digit number, `MONTH` and `DAY` are both two-digit numbers, and `MARKUP` is the file extension representing the format used in the file. After that, include the necessary front matter. Take a look at the source for this post to get an idea about how it works.
 
@@ -28,5 +28,6 @@ Check out the [Jekyll docs][jekyll-docs] for more info on how to get the most ou
 [jekyll-docs]: https://jekyllrb.com/docs/home
 [jekyll-gh]:   https://github.com/jekyll/jekyll
 [jekyll-talk]: https://talk.jekyllrb.com/
+
 
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added personal blog text to the default Jekyll welcome post. The change includes a typo ("psot" instead of "post") and is positioned awkwardly in the middle of Jekyll's formatting documentation.

- Spelling error needs correction on line 12
- Text placement interrupts the flow of Jekyll documentation between the format example and its explanation
- Extra blank line added at end of file

<h3>Confidence Score: 3/5</h3>

- This PR is safe to merge but contains minor issues that should be addressed
- Score reflects a simple content change with a spelling error and awkward text placement that doesn't affect functionality but impacts readability
- The markdown file needs attention for the typo correction and text repositioning

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| _posts/2021-12-23-welcome-to-jekyll.markdown | Added personal blog text with typo and awkward placement interrupting Jekyll documentation |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Author as Author
    participant File as Jekyll Post File
    participant Jekyll as Jekyll Site Generator
    participant Reader as Blog Reader
    
    Author->>File: Add personal text "this is my first blog psot"
    Author->>File: Add blank line at end
    File->>Jekyll: Process markdown file
    Jekyll->>Jekyll: Render post with changes
    Jekyll->>Reader: Display blog post with added text
    Note over Reader: Text appears mid-explanation,<br/>interrupting Jekyll format docs
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->