### PR TITLE
Hofm t patch 6

### DIFF
--- a/_posts/2021-12-23-welcome-to-jekyll.markdown
+++ b/_posts/2021-12-23-welcome-to-jekyll.markdown
@@ -20,7 +20,7 @@ def print_hi(name)
   puts "Hi, #{name}, How are you?"
 end
 print_hi('Tom')
-#=> prints 'Hi, Tom, How are you?' to STDOUT.
+#=> prints 'Hi, Tom?' to STDOUT.
 {% endhighlight %}
 
 Check out the [Jekyll docs][jekyll-docs] for more info on how to get the most out of Jekyll. File all bugs/feature requests at [Jekyll’s GitHub repo][jekyll-gh]. If you have questions, you can ask them on [Jekyll Talk][jekyll-talk].
@@ -28,7 +28,3 @@ Check out the [Jekyll docs][jekyll-docs] for more info on how to get the most ou
 [jekyll-docs]: https://jekyllrb.com/docs/home
 [jekyll-gh]:   https://github.com/jekyll/jekyll
 [jekyll-talk]: https://talk.jekyllrb.com/
-
-
-
-

--- a/_posts/2021-12-23-welcome-to-jekyll.markdown
+++ b/_posts/2021-12-23-welcome-to-jekyll.markdown
@@ -19,7 +19,7 @@ def print_hi(name)
   puts "Hi, #{name}, How are you?"
 end
 print_hi('Tom')
-#=> prints 'Hi, Tom' to STDOUT.
+#=> prints 'Hi, Tom, How are you?' to STDOUT.
 {% endhighlight %}
 
 Check out the [Jekyll docs][jekyll-docs] for more info on how to get the most out of Jekyll. File all bugs/feature requests at [Jekyll’s GitHub repo][jekyll-gh]. If you have questions, you can ask them on [Jekyll Talk][jekyll-talk].
@@ -27,5 +27,6 @@ Check out the [Jekyll docs][jekyll-docs] for more info on how to get the most ou
 [jekyll-docs]: https://jekyllrb.com/docs/home
 [jekyll-gh]:   https://github.com/jekyll/jekyll
 [jekyll-talk]: https://talk.jekyllrb.com/
+
 
 

--- a/_posts/2021-12-23-welcome-to-jekyll.markdown
+++ b/_posts/2021-12-23-welcome-to-jekyll.markdown
@@ -9,6 +9,7 @@ You’ll find this post in your `_posts` directory. Go ahead and edit it and re-
 Jekyll requires blog post files to be named according to the following format:
 
 `YEAR-MONTH-DAY-title.MARKUP`
+=== This is a new blog post ===
 
 Where `YEAR` is a four-digit number, `MONTH` and `DAY` are both two-digit numbers, and `MARKUP` is the file extension representing the format used in the file. After that, include the necessary front matter. Take a look at the source for this post to get an idea about how it works.
 
@@ -27,6 +28,7 @@ Check out the [Jekyll docs][jekyll-docs] for more info on how to get the most ou
 [jekyll-docs]: https://jekyllrb.com/docs/home
 [jekyll-gh]:   https://github.com/jekyll/jekyll
 [jekyll-talk]: https://talk.jekyllrb.com/
+
 
 
 

--- a/_posts/2021-12-23-welcome-to-jekyll.markdown
+++ b/_posts/2021-12-23-welcome-to-jekyll.markdown
@@ -9,6 +9,7 @@ You’ll find this post in your `_posts` directory. Go ahead and edit it and re-
 Jekyll requires blog post files to be named according to the following format:
 
 `YEAR-MONTH-DAY-title.MARKUP`
+this is my first blog post
 
 Where `YEAR` is a four-digit number, `MONTH` and `DAY` are both two-digit numbers, and `MARKUP` is the file extension representing the format used in the file. After that, include the necessary front matter. Take a look at the source for this post to get an idea about how it works.
 
@@ -27,3 +28,4 @@ Check out the [Jekyll docs][jekyll-docs] for more info on how to get the most ou
 [jekyll-docs]: https://jekyllrb.com/docs/home
 [jekyll-gh]:   https://github.com/jekyll/jekyll
 [jekyll-talk]: https://talk.jekyllrb.com/
+

--- a/_posts/2021-12-23-welcome-to-jekyll.markdown
+++ b/_posts/2021-12-23-welcome-to-jekyll.markdown
@@ -9,7 +9,6 @@ You’ll find this post in your `_posts` directory. Go ahead and edit it and re-
 Jekyll requires blog post files to be named according to the following format:
 
 `YEAR-MONTH-DAY-title.MARKUP`
-this is my first blog post
 
 Where `YEAR` is a four-digit number, `MONTH` and `DAY` are both two-digit numbers, and `MARKUP` is the file extension representing the format used in the file. After that, include the necessary front matter. Take a look at the source for this post to get an idea about how it works.
 
@@ -17,7 +16,7 @@ Jekyll also offers powerful support for code snippets:
 
 {% highlight ruby %}
 def print_hi(name)
-  puts "Hi, #{name}"
+  puts "Hi, #{name}, How are you?"
 end
 print_hi('Tom')
 #=> prints 'Hi, Tom' to STDOUT.
@@ -28,4 +27,5 @@ Check out the [Jekyll docs][jekyll-docs] for more info on how to get the most ou
 [jekyll-docs]: https://jekyllrb.com/docs/home
 [jekyll-gh]:   https://github.com/jekyll/jekyll
 [jekyll-talk]: https://talk.jekyllrb.com/
+
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes small edits to the default Jekyll welcome post: it inserts a `=== This is a new blog post ===` line and updates the Ruby snippet to greet with `"How are you?"`. The expected-output comment (`'Hi, Tom?'`) does not match the actual output of the updated `puts` call and should be corrected before merging.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the incorrect expected-output comment in the Ruby snippet.

One P1 finding: the expected output comment contradicts the updated code, making the published example incorrect for readers. The stray heading line is P2 but also worth cleaning up before publishing.

_posts/2021-12-23-welcome-to-jekyll.markdown — incorrect output comment and stray text on lines 12 and 22.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| _posts/2021-12-23-welcome-to-jekyll.markdown | Minor edits to the default Jekyll welcome post: adds stray `=== This is a new blog post ===` text and updates the Ruby snippet greeting, but the expected output comment is now wrong (`'Hi, Tom?'` instead of `'Hi, Tom, How are you?'`). |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: _posts/2021-12-23-welcome-to-jekyll.markdown
Line: 22

Comment:
**Incorrect expected output comment**

The comment says `'Hi, Tom?'` but the updated `puts` statement actually produces `Hi, Tom, How are you?`. The trailing `?` alone doesn't match the greeting string, so the example is now internally inconsistent.

```suggestion
#=> prints 'Hi, Tom, How are you?' to STDOUT.
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: _posts/2021-12-23-welcome-to-jekyll.markdown
Line: 12

Comment:
**Stray test content in post body**

The line `=== This is a new blog post ===` appears to be leftover test/scratch text inserted between the filename-format code block and the explanatory paragraph. It will render as raw prose on the published site and looks unintentional.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Update 2021-12-23-welcome-to-jekyll.mark..."](https://github.com/hofmt/hofmt.github.io/commit/00db0b1f908def30a4c38eee325af0703510d37c) | [Re-trigger Greptile](http://localhost:3000/api/retrigger?id=145)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->